### PR TITLE
Add exchange rate overrides

### DIFF
--- a/stable-swap-anchor/src/instructions.rs
+++ b/stable-swap-anchor/src/instructions.rs
@@ -356,3 +356,39 @@ pub fn set_new_fees<'a, 'b, 'c, 'info>(
     solana_program::program::invoke_signed(&ix, &ctx.to_account_infos(), ctx.signer_seeds)?;
     Ok(())
 }
+
+/// Creates and invokes a [stable_swap_client::instruction::set_token_a_exchange_rate_override] instruction.
+///
+/// # Arguments
+///
+/// * `exchange_rate_override` - new [`stable_swap_client::fraction::Fraction`].
+pub fn set_token_a_exchange_rate_override<'a, 'b, 'c, 'info>(
+    ctx: CpiContext<'a, 'b, 'c, 'info, AdminUserContext<'info>>,
+    exchange_rate_override: stable_swap_client::fraction::Fraction,
+) -> Result<()> {
+    let ix = stable_swap_client::instruction::set_token_a_exchange_rate_override(
+        ctx.accounts.swap.key,
+        ctx.accounts.admin.key,
+        exchange_rate_override,
+    )?;
+    solana_program::program::invoke_signed(&ix, &ctx.to_account_infos(), ctx.signer_seeds)?;
+    Ok(())
+}
+
+/// Creates and invokes a [stable_swap_client::instruction::set_token_b_exchange_rate_override] instruction.
+///
+/// # Arguments
+///
+/// * `exchange_rate_override` - new [`stable_swap_client::fraction::Fraction`].
+pub fn set_token_b_exchange_rate_override<'a, 'b, 'c, 'info>(
+    ctx: CpiContext<'a, 'b, 'c, 'info, AdminUserContext<'info>>,
+    exchange_rate_override: stable_swap_client::fraction::Fraction,
+) -> Result<()> {
+    let ix = stable_swap_client::instruction::set_token_b_exchange_rate_override(
+        ctx.accounts.swap.key,
+        ctx.accounts.admin.key,
+        exchange_rate_override,
+    )?;
+    solana_program::program::invoke_signed(&ix, &ctx.to_account_infos(), ctx.signer_seeds)?;
+    Ok(())
+}

--- a/stable-swap-client/src/error.rs
+++ b/stable-swap-client/src/error.rs
@@ -98,6 +98,9 @@ pub enum SwapError {
     /// Token mint decimals must be the same.
     #[error("Token mints must have same decimals")]
     MismatchedDecimals,
+    /// Exchange rate override cannot be x/0 or 0/x, where x != 0
+    #[error("Exchange rate override cannot be 0 or infinity")]
+    InvalidExchangeRateOverride,
 }
 
 impl From<SwapError> for ProgramError {
@@ -173,6 +176,9 @@ impl PrintProgramError for SwapError {
             SwapError::NoActiveTransfer => msg!("Error: No active admin transfer in progress"),
             SwapError::AdminDeadlineExceeded => msg!("Error: Admin transfer deadline exceeded"),
             SwapError::MismatchedDecimals => msg!("Error: Token mints must have same decimals"),
+            SwapError::InvalidExchangeRateOverride => {
+                msg!("Error: Exchange rate override cannot be 0 or infinity")
+            }
         }
     }
 }

--- a/stable-swap-client/src/fraction.rs
+++ b/stable-swap-client/src/fraction.rs
@@ -1,0 +1,66 @@
+//! Program fraction
+
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_program::{
+    program_error::ProgramError,
+    program_pack::{Pack, Sealed},
+};
+
+/// Fraction struct
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct Fraction {
+    /// Numerator
+    pub numerator: u64,
+    /// Denominator
+    pub denominator: u64,
+}
+
+impl Sealed for Fraction {}
+impl Pack for Fraction {
+    const LEN: usize = 16;
+    fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
+        let input = array_ref![input, 0, 16];
+        #[allow(clippy::ptr_offset_with_cast)]
+        let (numerator, denominator) = array_refs![input, 8, 8];
+        Ok(Self {
+            numerator: u64::from_le_bytes(*numerator),
+            denominator: u64::from_le_bytes(*denominator),
+        })
+    }
+
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        let output = array_mut_ref![output, 0, 16];
+        let (numerator, denominator) = mut_array_refs![output, 8, 8];
+        *numerator = self.numerator.to_le_bytes();
+        *denominator = self.denominator.to_le_bytes();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_fraction() {
+        let numerator = 1;
+        let denominator = 2;
+        let fraction = Fraction {
+            numerator,
+            denominator,
+        };
+
+        let mut packed = [0u8; Fraction::LEN];
+        Pack::pack_into_slice(&fraction, &mut packed[..]);
+        let unpacked = Fraction::unpack_from_slice(&packed).unwrap();
+        assert_eq!(fraction, unpacked);
+
+        let mut packed = vec![];
+        packed.extend_from_slice(&numerator.to_le_bytes());
+        packed.extend_from_slice(&denominator.to_le_bytes());
+        let unpacked = Fraction::unpack_from_slice(&packed).unwrap();
+        assert_eq!(fraction, unpacked);
+    }
+}

--- a/stable-swap-client/src/lib.rs
+++ b/stable-swap-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod error;
 pub mod fees;
+pub mod fraction;
 pub mod instruction;
 pub mod state;
 

--- a/stable-swap-program/program/src/processor/swap.rs
+++ b/stable-swap-program/program/src/processor/swap.rs
@@ -10,6 +10,7 @@ use crate::{
     processor::utils,
     state::{SwapInfo, SwapTokenInfo},
 };
+use stable_swap_client::fraction::Fraction;
 use stable_swap_math::curve::{StableSwap, MAX_AMP, MIN_AMP, ZERO_TS};
 use stable_swap_math::math::FeeCalculator;
 
@@ -267,6 +268,14 @@ fn process_initialize(
         },
         pool_mint: *pool_mint_info.key,
         fees,
+        token_a_exchange_rate_override: Fraction {
+            numerator: 0,
+            denominator: 0,
+        },
+        token_b_exchange_rate_override: Fraction {
+            numerator: 0,
+            denominator: 0,
+        },
     };
     SwapInfo::pack(obj, &mut swap_info.data.borrow_mut())?;
 

--- a/stable-swap-program/program/src/processor/test_utils.rs
+++ b/stable-swap-program/program/src/processor/test_utils.rs
@@ -14,6 +14,7 @@ use spl_token::{
     instruction::{initialize_account, initialize_mint, mint_to},
     state::{Account as SplAccount, Mint as SplMint},
 };
+use stable_swap_client::fraction::Fraction;
 
 /// Test program id for the swap program.
 pub static SWAP_PROGRAM_ID: Pubkey = crate::ID;
@@ -554,6 +555,36 @@ impl SwapAccountInfo {
     pub fn set_new_fees(&mut self, new_fees: Fees) -> ProgramResult {
         do_process_instruction(
             set_new_fees(&self.swap_key, &self.admin_key, new_fees).unwrap(),
+            vec![&mut self.swap_account, &mut self.admin_account],
+        )
+    }
+
+    pub fn set_token_a_exchange_rate_override(
+        &mut self,
+        exchange_rate_override: Fraction,
+    ) -> ProgramResult {
+        do_process_instruction(
+            set_token_a_exchange_rate_override(
+                &self.swap_key,
+                &self.admin_key,
+                exchange_rate_override,
+            )
+            .unwrap(),
+            vec![&mut self.swap_account, &mut self.admin_account],
+        )
+    }
+
+    pub fn set_token_b_exchange_rate_override(
+        &mut self,
+        exchange_rate_override: Fraction,
+    ) -> ProgramResult {
+        do_process_instruction(
+            set_token_b_exchange_rate_override(
+                &self.swap_key,
+                &self.admin_key,
+                exchange_rate_override,
+            )
+            .unwrap(),
             vec![&mut self.swap_account, &mut self.admin_account],
         )
     }


### PR DESCRIPTION
- Adds `token_a_exchange_rate_override` and `token_b_exchange_rate_override` which are of type `Fraction`. If these are `0/0`, then we treat this as there being no override (this could be debatable; maybe we want `0/0` to be invalid and if we want to undo the override, we set to `1/1` or something).
- Adds setter functions for these new fields.
- Adds unit tests.

This PR does not use these fields in swapping at all. That will come in a future PR.