### PR TITLE
Kill solana-test-validator after do.sh finishes running

### DIFF
--- a/stable-swap-program/do.sh
+++ b/stable-swap-program/do.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -ex
+trap "exit" INT TERM
+trap "kill 0" EXIT
 cd "$(dirname "$0")"
 
 export PATH="$HOME"/.local/share/solana/install/active_release/bin:"$PATH"


### PR DESCRIPTION
Before, running `ps aux | grep solana` after running `./do.sh test` would show that the `solana-test-validator` was still running. Now, that validator will be killed when `do.sh` exits.