### PR TITLE
Make error checking more robust, refactor tests

### DIFF
--- a/stable-swap-client/src/error.rs
+++ b/stable-swap-client/src/error.rs
@@ -101,6 +101,9 @@ pub enum SwapError {
     /// Exchange rate override cannot be x/0 or 0/x, where x != 0
     #[error("Exchange rate override cannot be 0 or infinity")]
     InvalidExchangeRateOverride,
+    /// Failed to get exchange rate.
+    #[error("Failed to get exchange rate")]
+    FailedToGetExchangeRate,
 }
 
 impl From<SwapError> for ProgramError {
@@ -178,6 +181,9 @@ impl PrintProgramError for SwapError {
             SwapError::MismatchedDecimals => msg!("Error: Token mints must have same decimals"),
             SwapError::InvalidExchangeRateOverride => {
                 msg!("Error: Exchange rate override cannot be 0 or infinity")
+            }
+            SwapError::FailedToGetExchangeRate => {
+                msg!("Error: Failed to get exchange rate")
             }
         }
     }

--- a/stable-swap-client/src/state.rs
+++ b/stable-swap-client/src/state.rs
@@ -83,14 +83,12 @@ impl SwapInfo {
 
     /// Calculates the exchange rate of the token corresponding with 'key'.
     /// Assumes that 'key' corresponds with either token A or token B.
-    pub fn exchange_rate_from_token_account(&self, key: Pubkey) -> Fraction {
-        if key == self.token_a.reserves {
-            return self.exchange_rate_a();
+    pub fn exchange_rate_from_token_account(&self, key: Pubkey) -> Option<Fraction> {
+        match key {
+            key if key == self.token_a.reserves => Some(self.exchange_rate_a()),
+            key if key == self.token_b.reserves => Some(self.exchange_rate_b()),
+            _ => None,
         }
-        if key == self.token_b.reserves {
-            return self.exchange_rate_b();
-        }
-        Fraction::UNDEFINED
     }
 }
 

--- a/stable-swap-program/program/src/processor/macros.rs
+++ b/stable-swap-program/program/src/processor/macros.rs
@@ -73,3 +73,14 @@ macro_rules! check_token_keys_condition {
         }
     };
 }
+
+/// Adaptation of viper's `unwrap_opt`, compatible with non-Anchor errors.
+macro_rules! unwrap_opt {
+    ($option:expr, $err:expr $(,)?) => {
+        $option.ok_or_else(|| -> ProgramError {
+            msg!(stringify!($option));
+            msg!("Error thrown at {}:{}", file!(), line!());
+            $err
+        })?
+    };
+}

--- a/stable-swap-program/program/src/processor/swap.rs
+++ b/stable-swap-program/program/src/processor/swap.rs
@@ -29,22 +29,6 @@ use super::checks::*;
 use super::logging::*;
 use super::token;
 
-macro_rules! log_code_location {
-    () => {
-        msg!("Error thrown at {}:{}", file!(), line!());
-    };
-}
-
-macro_rules! unwrap_opt {
-    ($option:expr, $err:expr $(,)?) => {
-        $option.ok_or_else(|| -> ProgramError {
-            msg!(stringify!($option));
-            log_code_location!();
-            $err
-        })?
-    };
-}
-
 pub fn process_swap_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/stable-swap-program/program/src/processor/swap.rs
+++ b/stable-swap-program/program/src/processor/swap.rs
@@ -29,6 +29,22 @@ use super::checks::*;
 use super::logging::*;
 use super::token;
 
+macro_rules! log_code_location {
+    () => {
+        msg!("Error thrown at {}:{}", file!(), line!());
+    };
+}
+
+macro_rules! unwrap_opt {
+    ($option:expr, $err:expr $(,)?) => {
+        $option.ok_or_else(|| -> ProgramError {
+            msg!(stringify!($option));
+            log_code_location!();
+            $err
+        })?
+    };
+}
+
 pub fn process_swap_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -389,8 +405,14 @@ fn process_swap(
             amount_in,
             swap_source_account.amount,
             swap_destination_account.amount,
-            token_swap.exchange_rate_from_token_account(*swap_source_info.key),
-            token_swap.exchange_rate_from_token_account(*swap_destination_info.key),
+            unwrap_opt!(
+                token_swap.exchange_rate_from_token_account(*swap_source_info.key),
+                SwapError::FailedToGetExchangeRate.into()
+            ),
+            unwrap_opt!(
+                token_swap.exchange_rate_from_token_account(*swap_destination_info.key),
+                SwapError::FailedToGetExchangeRate.into()
+            ),
             &token_swap.fees,
         )
         .ok_or(SwapError::CalculationFailure)?;
@@ -797,8 +819,14 @@ fn process_withdraw_one(
             pool_mint.supply,
             base_token.amount,
             quote_token.amount,
-            token_swap.exchange_rate_from_token_account(*base_token_info.key),
-            token_swap.exchange_rate_from_token_account(*quote_token_info.key),
+            unwrap_opt!(
+                token_swap.exchange_rate_from_token_account(*base_token_info.key),
+                SwapError::FailedToGetExchangeRate.into()
+            ),
+            unwrap_opt!(
+                token_swap.exchange_rate_from_token_account(*quote_token_info.key),
+                SwapError::FailedToGetExchangeRate.into()
+            ),
             &token_swap.fees,
         )
         .ok_or(SwapError::CalculationFailure)?;


### PR DESCRIPTION
- Reduce the diff size in `curve.rs` tests. All the original tests are unmodified now.
- Make it impossible for `exchange_rate_from_token_account` to return an invalid fraction. Technically it's impossible right now for this to happen, but it's good to be future proof.