### PR TITLE
deps: bump uint to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,9 +1899,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/stable-swap-math/Cargo.toml
+++ b/stable-swap-math/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["solana", "saber", "math"]
 borsh = "0.9.2"
 num-traits = "0.2"
 stable-swap-client = { path = "../stable-swap-client", version = "^1" }
-# This must be pinned to 0.9.1 until Solana's Rust fork supports Rust >=1.56.1
-uint = { version = "=0.9.1", default-features = false }
+uint = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 proptest = "1.0.0"


### PR DESCRIPTION
It was pinned to 0.9.1 as 0.9.2 broke with an older compiler. This is no longer an issue.

The motivation to update is that uint 0.9.1 emits a clippy warning in later rustc versions, and this can either cause warnings or errors depending on a dependant's strictness.